### PR TITLE
build: upgrade sbt-protobuf to v0.5.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "com.trueaccord.scalapb"
 
 name := "sbt-scalapb"
 
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.5.2")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.5.3")
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 


### PR DESCRIPTION
In order to align `com.google.protobuf:protobuf-java:2.6.1 -> 3.0.0` when using ScalaPB.
